### PR TITLE
Wire contact form to POST /api/contact via Email Routing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,8 +62,7 @@ Fonts: JetBrains Mono (body/UI), Space Grotesk (headings).
   frontmatter
 - `public/resume.pdf` — copy of the real resume; replace when it updates
 - Interactivity is small vanilla `<script>` blocks per page (modals via
-  native `<dialog>`, blog filters, mailto contact form — swap to a
-  Cloudflare Function later)
+  native `<dialog>`, blog filters, contact form fetch)
 - `src/scripts/flightdeck/` — the `/` canvas game as plain-TS modules
   (`background`/`deck`/`lander`/`particles` + controller in `index.ts`);
   `index.astro` owns all DOM (HUD, cards, boot, touch) and wires it via
@@ -73,12 +72,16 @@ Fonts: JetBrains Mono (body/UI), Space Grotesk (headings).
   (`sessionStorage`)
 - `worker/index.ts` — the Workers script behind `/api/*`: anonymous play
   counters (`POST /api/play`, `GET /api/plays`) in the `PLAYS` KV
-  namespace. No cookies/IDs by design — keep it that way (no consent
-  banner needed). `index.astro` fires the beacons (first control input =
-  deck play, user-driven lander entry = lander play)
+  namespace, and the contact form (`POST /api/contact` → email via the
+  `send_email` binding + `mimetext/browser`; honeypot anti-spam, nothing
+  stored). Requires Email Routing enabled on the domain with the
+  destination address verified — deploys fail otherwise. No cookies/IDs
+  by design — keep it that way (no consent banner needed). `index.astro`
+  fires the beacons (first control input = deck play, user-driven lander
+  entry = lander play)
 - Status: content pages and the `/` flight-deck game (deck + lander)
-  match the design; play counters wired up; SEO + social share cards
-  done; remaining: contact-form Cloudflare Function, more blog posts
+  match the design; play counters and contact form wired up; SEO +
+  social share cards done; remaining: more blog posts
 
 ## Principles
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "@astrojs/mdx": "^7.0.3",
-    "astro": "^7.1.3"
+    "astro": "^7.1.3",
+    "mimetext": "^3.0.28"
   },
   "devDependencies": {
     "@astrojs/sitemap": "^3.7.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       astro:
         specifier: ^7.1.3
         version: 7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.13.3)(rollup@4.62.2)
+      mimetext:
+        specifier: ^3.0.28
+        version: 3.0.28
     devDependencies:
       '@astrojs/sitemap':
         specifier: ^3.7.3
@@ -133,6 +136,14 @@ packages:
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/runtime-corejs3@7.29.7':
+    resolution: {integrity: sha512-ppj9ouYku+RX0ljtgZd+KMO5mkM2bCqg8H2PYAFWnLsHEIKIdRojqbJ2i3eVHrisuxy7nOFCmngTDdWtUCdXUQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
@@ -1097,6 +1108,9 @@ packages:
     resolution: {integrity: sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==}
     engines: {node: '>=22'}
 
+  core-js-pure@3.50.0:
+    resolution: {integrity: sha512-6GP3Pxz4IKyWjAfa747vIu/jilB5z29JWROLqH/b+pXVcpgh6tM06ZIBwSuglgVqzDYURhOK6oEzTrG0bCHitA==}
+
   crossws@0.3.5:
     resolution: {integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==}
 
@@ -1378,6 +1392,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  js-base64@3.9.2:
+    resolution: {integrity: sha512-6zayE8QlUdiweYI6cETD/XBSqFcoCUlufn/29PJR99r82x1yDnIprRca0YvAYpAW+ez0GuQkVBC6xG5QkD7OjA==}
+
   js-yaml@4.3.0:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
@@ -1643,6 +1660,17 @@ packages:
 
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mimetext@3.0.28:
+    resolution: {integrity: sha512-eQXpbNrtxLCjUtiVbR/qR09dbPgZ2o+KR1uA7QKqGhbn8QV7HIL16mXXsobBL4/8TqoYh1us31kfz+dNfCev9g==}
 
   miniflare@4.20260722.0:
     resolution: {integrity: sha512-LW6ABMhCx/yIEFBLC/DO4yAhdm2T/G7jp7pr5T2kj895+CCIaHZqpMXdW9O6YE48LcYcCJChwWc8aEs1vpbTXw==}
@@ -2322,6 +2350,12 @@ snapshots:
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
+
+  '@babel/runtime-corejs3@7.29.7':
+    dependencies:
+      core-js-pure: 3.50.0
+
+  '@babel/runtime@7.29.7': {}
 
   '@babel/types@7.29.7':
     dependencies:
@@ -3119,6 +3153,8 @@ snapshots:
 
   cookie@2.0.1: {}
 
+  core-js-pure@3.50.0: {}
+
   crossws@0.3.5:
     dependencies:
       uncrypto: 0.1.3
@@ -3502,6 +3538,8 @@ snapshots:
   is-hexadecimal@2.0.1: {}
 
   is-plain-obj@4.1.0: {}
+
+  js-base64@3.9.2: {}
 
   js-yaml@4.3.0:
     dependencies:
@@ -4019,6 +4057,19 @@ snapshots:
       micromark-util-types: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mimetext@3.0.28:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@babel/runtime-corejs3': 7.29.7
+      js-base64: 3.9.2
+      mime-types: 2.1.35
 
   miniflare@4.20260722.0:
     dependencies:

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,6 +1,7 @@
 ---
-// Contact — form + direct channels (design/Site.dc.html, #contact).
-// The form composes a mailto: draft until the Cloudflare Function exists.
+// Contact — form + direct channels (design/v2/design/Site.dc.html, #contact).
+// The form POSTs to the worker's /api/contact, which emails the message
+// via Email Routing; on failure it falls back to a mailto link.
 import Site from "../layouts/Site.astro";
 import { SITE } from "../data/site";
 
@@ -59,6 +60,26 @@ const channels = [
           />
         </div>
         <div class="field">
+          <label for="f-email">email</label>
+          <input
+            id="f-email"
+            name="email"
+            required
+            type="email"
+            placeholder="ada@analytical.engine"
+          />
+        </div>
+        <div class="field hp" aria-hidden="true">
+          <label for="f-website">website</label>
+          <input
+            id="f-website"
+            name="website"
+            type="text"
+            tabindex="-1"
+            autocomplete="off"
+          />
+        </div>
+        <div class="field">
           <label for="f-subject">subject</label>
           <input
             id="f-subject"
@@ -76,10 +97,18 @@ const channels = [
             placeholder="tell me what you're building..."></textarea>
         </div>
         <button type="submit">send message →</button>
-        <div class="note">
-          Opens a draft in your mail client — or just email me directly.
+        <div class="note" id="contact-note">
+          Delivered straight to my inbox — or just email me directly.
         </div>
       </form>
+      <div class="sent" id="contact-sent" hidden>
+        <div class="sent-check">✓</div>
+        <div class="sent-title">message queued</div>
+        <div class="sent-sub">
+          Transmission logged. I'll get back to you shortly.
+        </div>
+        <button type="button" id="contact-reset">send another</button>
+      </div>
     </div>
 
     <div class="channels">
@@ -192,6 +221,61 @@ const channels = [
     color: var(--text-ghost);
     line-height: 1.5;
   }
+  .note.error {
+    color: var(--amber);
+  }
+  .note.error a {
+    color: var(--amber);
+    text-decoration: underline;
+  }
+
+  /* Honeypot — visually gone, still in the DOM for bots to fill. */
+  .hp {
+    position: absolute;
+    left: -9999px;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+  }
+
+  form[hidden] {
+    display: none;
+  }
+  .sent {
+    text-align: center;
+    padding: 24px 8px;
+  }
+  .sent-check {
+    font-size: 34px;
+    color: var(--green);
+    margin-bottom: 12px;
+  }
+  .sent-title {
+    font-family: var(--font-display);
+    font-size: 19px;
+    font-weight: 600;
+    color: var(--text-bright);
+    margin-bottom: 6px;
+  }
+  .sent-sub {
+    font-size: 13px;
+    color: var(--text-muted);
+    margin-bottom: 20px;
+  }
+  #contact-reset {
+    cursor: pointer;
+    display: inline-block;
+    font-size: 12.5px;
+    color: var(--cyan);
+    background: none;
+    border: 1px solid rgba(34, 211, 238, 0.4);
+    padding: 8px 16px;
+    border-radius: 7px;
+    transition: background 0.15s;
+  }
+  #contact-reset:hover {
+    background: rgba(34, 211, 238, 0.1);
+  }
 
   .channels {
     display: flex;
@@ -240,12 +324,39 @@ const channels = [
 
 <script>
   const form = document.getElementById("contact-form") as HTMLFormElement;
-  form.addEventListener("submit", (e) => {
+  const sent = document.getElementById("contact-sent") as HTMLElement;
+  const note = document.getElementById("contact-note") as HTMLElement;
+  const reset = document.getElementById("contact-reset") as HTMLButtonElement;
+  const submit = form.querySelector("button[type=submit]") as HTMLButtonElement;
+  const defaultNote = note.textContent;
+
+  form.addEventListener("submit", async (e) => {
     e.preventDefault();
-    const data = new FormData(form);
-    const subject = String(data.get("subject") || "Hello from your portfolio");
-    const body = `${data.get("message")}\n\n— ${data.get("name")}`;
-    const email = form.dataset.email;
-    location.href = `mailto:${email}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+    submit.disabled = true;
+    submit.textContent = "transmitting...";
+    try {
+      const res = await fetch("/api/contact", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(Object.fromEntries(new FormData(form))),
+      });
+      if (!res.ok) throw new Error(`status ${res.status}`);
+      form.reset();
+      note.classList.remove("error");
+      note.textContent = defaultNote;
+      form.hidden = true;
+      sent.hidden = false;
+    } catch {
+      note.classList.add("error");
+      note.innerHTML = `transmission failed — try again or <a href="mailto:${form.dataset.email}">email me directly</a>.`;
+    } finally {
+      submit.disabled = false;
+      submit.textContent = "send message →";
+    }
+  });
+
+  reset.addEventListener("click", () => {
+    sent.hidden = true;
+    form.hidden = false;
   });
 </script>

--- a/worker/email.d.ts
+++ b/worker/email.d.ts
@@ -1,0 +1,7 @@
+// Minimal ambient declaration for the cloudflare:email runtime module,
+// matching the local-types approach in index.ts (no @cloudflare/workers-types).
+declare module "cloudflare:email" {
+  export class EmailMessage {
+    constructor(from: string, to: string, raw: string);
+  }
+}

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,8 +1,13 @@
-// Play counter: anonymous per-day tallies in KV, no cookies or IDs.
+// /api/* worker: anonymous play counters in KV plus the contact form.
 // POST /api/play?game=deck|lander bumps a counter; GET /api/plays reads
-// them back as JSON. Everything else falls through to the static assets.
+// them back as JSON; POST /api/contact emails the message via the
+// send_email binding (Email Routing). No cookies or IDs anywhere.
+// Everything else falls through to the static assets.
 // Minimal local types instead of @cloudflare/workers-types — the worker
 // only touches this slice of the API.
+
+import { EmailMessage } from "cloudflare:email";
+import { createMimeMessage, Mailbox } from "mimetext/browser";
 
 interface KV {
   get(key: string): Promise<string | null>;
@@ -13,10 +18,60 @@ interface KV {
 interface Env {
   ASSETS: { fetch(request: Request): Promise<Response> };
   PLAYS: KV;
+  CONTACT_EMAIL: { send(message: EmailMessage): Promise<void> };
 }
 
 const GAMES = ["deck", "lander"] as const;
 const DAY_KEY_TTL = 60 * 60 * 24 * 60; // daily keys expire after 60 days
+
+// From must live on the Email Routing domain; the recipient must match a
+// verified destination address (see the send_email binding in wrangler.jsonc).
+const CONTACT_FROM = "contact@waleedali.dev";
+const CONTACT_TO = "waleedali070@gmail.com";
+const LIMITS = { name: 200, email: 320, subject: 200, message: 5000 } as const;
+
+async function handleContact(request: Request, env: Env): Promise<Response> {
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "invalid JSON" }, { status: 400 });
+  }
+
+  const field = (key: keyof typeof LIMITS) =>
+    typeof body[key] === "string" ? (body[key] as string).trim().slice(0, LIMITS[key]) : "";
+  const name = field("name");
+  const email = field("email");
+  const subject = field("subject") || "Message from waleedali.dev";
+  const message = field("message");
+
+  // Honeypot: bots fill the hidden "website" field — pretend it worked.
+  if (typeof body.website === "string" && body.website.trim() !== "") {
+    return new Response(null, { status: 204 });
+  }
+  if (!name || !message || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return Response.json({ error: "missing or invalid fields" }, { status: 400 });
+  }
+
+  const mime = createMimeMessage();
+  mime.setSender({ name: `${name} via waleedali.dev`, addr: CONTACT_FROM });
+  mime.setRecipient(CONTACT_TO);
+  mime.setHeader("Reply-To", new Mailbox(email));
+  mime.setSubject(subject);
+  // Base64 body: the default 7bit transfer encoding can mangle non-ASCII text.
+  mime.addMessage({
+    contentType: "text/plain",
+    encoding: "base64",
+    data: mime.toBase64(`${message}\n\n— ${name} <${email}>`),
+  });
+
+  try {
+    await env.CONTACT_EMAIL.send(new EmailMessage(CONTACT_FROM, CONTACT_TO, mime.asRaw()));
+  } catch {
+    return Response.json({ error: "send failed" }, { status: 502 });
+  }
+  return new Response(null, { status: 204 });
+}
 
 // KV read-modify-write isn't atomic; at portfolio traffic a lost
 // increment is acceptable noise.
@@ -36,6 +91,10 @@ export default {
       await bump(env.PLAYS, `${game}:total`);
       await bump(env.PLAYS, `${game}:d:${day}`, DAY_KEY_TTL);
       return new Response(null, { status: 204 });
+    }
+
+    if (url.pathname === "/api/contact" && request.method === "POST") {
+      return handleContact(request, env);
     }
 
     if (url.pathname === "/api/plays" && request.method === "GET") {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -14,5 +14,13 @@
       "binding": "PLAYS",
       "id": "37e39e7235764af2a77d607b030f185b"
     }
+  ],
+  // Contact form delivery — requires Email Routing enabled on the domain
+  // and this address verified as a destination in the Cloudflare dashboard.
+  "send_email": [
+    {
+      "name": "CONTACT_EMAIL",
+      "destination_address": "waleedali070@gmail.com"
+    }
   ]
 }


### PR DESCRIPTION
Worker sends the message with the send_email binding (mimetext/browser for MIME), Reply-To set to the visitor. Honeypot field for spam, nothing stored, no cookies. Form gains an email field and the design's 'message queued' success state, with a mailto fallback on error.